### PR TITLE
fix: restore card and profile layout to match Figma design

### DIFF
--- a/src/blocks/card.css
+++ b/src/blocks/card.css
@@ -2,11 +2,18 @@
   max-width: 413px;
 }
 
-.card__image {
-  width: 413px; /* width and height keep image correct size*/
+.card__image-content {
+  position: relative;
+  width: 413px;
   height: 413px;
   border-radius: 8px;
-  object-fit: cover; /* keeps images looking nice */
+  overflow: hidden;
+}
+
+.card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   cursor: pointer;
 }
 
@@ -33,14 +40,15 @@
 }
 
 .card__delete-button {
-  position: absolute; /* having absolute makes sure each card has a button and in the correct spot*/
-  margin: 10px 371px 0;
-  padding: 0; /* controls size of svg i guess */
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 0;
   background-image: url(../images/delete-icon.svg);
-  background-repeat: no-repeat; /* this and bg size is keeping the icon true to size */
+  background-repeat: no-repeat;
   background-size: contain;
-  width: 32px; /*makes sure svg actually shows */
-  height: 32px; /*same as width*/
+  width: 32px;
+  height: 32px;
   border: none;
   background-color: transparent;
   opacity: 100%;
@@ -79,12 +87,25 @@
   opacity: 40%;
 }
 
+.card__like-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.card__like-count {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1;
+  color: rgba(33, 33, 33, 0.7);
+}
+
 @media screen and (max-width: 627px) {
   .card {
     max-width: 288px;
   }
 
-  .card__image {
+  .card__image-content {
     width: 288px;
     height: 288px;
   }
@@ -98,9 +119,5 @@
   .card__like-button {
     width: 20px;
     height: 18px;
-  }
-
-  .card__delete-button {
-    margin: 10px 246px 0;
   }
 }

--- a/src/blocks/profile.css
+++ b/src/blocks/profile.css
@@ -9,7 +9,11 @@
 .profile__avatar-container {
   position: relative;
   display: block;
+  width: 190px;
   height: 190px;
+  margin-right: 20px;
+  border-radius: 8px;
+  overflow: hidden;
   cursor: pointer;
 }
 
@@ -34,11 +38,9 @@
 
 /* Avatar image */
 .profile__avatar {
-  margin-right: 20px;
   height: 190px;
   width: 190px;
   border-radius: 8px;
-  z-index: 1;
 }
 
 /* Avatar edit button */
@@ -163,11 +165,12 @@
   .profile__avatar-container {
     height: 80px;
     width: 80px;
+    margin-right: 0;
+    margin-bottom: 12px;
     cursor: default;
   }
 
   .profile__avatar {
-    margin: 0 0 12px;
     height: 80px;
     width: 80px;
   }


### PR DESCRIPTION
- Add position:relative, dimensions, border-radius, overflow:hidden to card__image-content so the absolutely-positioned delete button anchors correctly to each card instead of the viewport
- Replace broken margin-based delete button positioning (margin: 10px 371px 0) with top:10px / right:10px
- Switch card__image from fixed 413px pixel sizes to width/height:100% so it fills its container responsively
- Add missing card__like-container (flex row) and card__like-count (text) CSS
- Update mobile breakpoint: resize card__image-content to 288px, remove the now-unnecessary mobile delete-button margin override
- Fix profile__avatar-container: set explicit width:190px, add overflow:hidden and border-radius:8px so the hover overlay clips to the avatar shape
- Move margin-right:20px from the avatar img (inside container) to the container itself so spacing is correct with overflow:hidden
- Fix mobile avatar: reset margin-right to 0, add margin-bottom:12px on the container instead of the clipped child image

https://claude.ai/code/session_019yNKAUKQg32nuUsvMj2eJn