### PR TITLE
fix: grant write permissions to GITHUB_TOKEN for gh-pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The peaceiris/actions-gh-pages action needs contents: write permission to push to the gh-branch. Without it, the GITHUB_TOKEN is read-only by default and the push fails with 403.

https://claude.ai/code/session_01E3EUP1JT2Vv5Nx5hWc2xSx